### PR TITLE
Fix for UnicodeEncodeError

### DIFF
--- a/Kindle2Txt.py
+++ b/Kindle2Txt.py
@@ -36,7 +36,7 @@ def save_sentences(book_data):
   now = datetime.now()
   filename = f'KindleVocab_{now.strftime("%Y%m%d-%H%M%S")}.txt'
   filename_path = os.path.join(config['output_path'], filename)
-  with open(filename_path, 'w') as f:
+  with open(filename_path, 'w', encoding="utf-8") as f:
     for title in book_data:
       if (len(book_data[title]) == 0):
         continue


### PR DESCRIPTION
Sets encoding on save to utf-8 so it doesn't get `UnicodeEncodeError: 'charmap' codec can't encode characters in position x-xx: character maps to <undefined>`.

I had to add the `encoding="utf-8"` part for the script to work.

And thanks for creating the script!

This is in Python 3.11.5 and when I run it on Windows 11.